### PR TITLE
Support external interrupts

### DIFF
--- a/hw/gr-heep/gr_heep.sv.tpl
+++ b/hw/gr-heep/gr_heep.sv.tpl
@@ -82,11 +82,11 @@ module gr_heep (
   obi_req_t  [ExtXbarNmasterRnd-1:0] heep_slave_req;
   obi_resp_t [ExtXbarNmasterRnd-1:0] heep_slave_rsp;
 
-% if (gr_heep["xbar_nslaves"] > 0):
-  // External slave ports
-  obi_req_t  [ExtXbarNSlaveRnd-1:0] gr_heep_slave_req;
-  obi_resp_t [ExtXbarNSlaveRnd-1:0] gr_heep_slave_resp;
-% endif
+  % if (gr_heep["xbar_nslaves"] > 0):
+    // External slave ports
+    obi_req_t  [ExtXbarNSlaveRnd-1:0] gr_heep_slave_req;
+    obi_resp_t [ExtXbarNSlaveRnd-1:0] gr_heep_slave_resp;
+  % endif
 
   // External master ports
   obi_req_t  [ExtXbarNmasterRnd-1:0] gr_heep_master_req;
@@ -267,93 +267,92 @@ module gr_heep (
     .exit_value_o (exit_value)
   );
 
-% if (gr_heep["xbar_nslaves"] > 0):
-    gr_heep_bus #(
-    .EXT_XBAR_NMASTER(gr_heep_pkg::ExtXbarNMaster),
-    .EXT_XBAR_NSLAVE (gr_heep_pkg::ExtXbarNSlave)
-  ) gr_heep_bus_i (
-    .clk_i(clk_in_x),
-    .rst_ni(rst_nin_sync),
-    .addr_map_i(gr_heep_pkg::ExtPeriphAddrRules),
-    .default_idx_i('0),
-    .heep_core_instr_req_i(heep_core_instr_req),
-    .heep_core_instr_resp_o(heep_core_instr_rsp),
-    .heep_core_data_req_i(heep_core_data_req),
-    .heep_core_data_resp_o(heep_core_data_rsp),
-    .heep_debug_master_req_i(heep_debug_master_req),
-    .heep_debug_master_resp_o(heep_debug_master_rsp),
-    .heep_dma_read_req_i(heep_dma_read_req),
-    .heep_dma_read_resp_o(heep_dma_read_rsp),
-    .heep_dma_write_req_i(heep_dma_write_req),
-    .heep_dma_write_resp_o(heep_dma_write_rsp),
-    .heep_dma_addr_req_i(heep_dma_addr_req),
-    .heep_dma_addr_resp_o(heep_dma_addr_rsp),
-    .ext_master_req_i(gr_heep_master_req),
-    .ext_master_resp_o(gr_heep_master_resp),
-    .heep_slave_req_o(heep_slave_req),
-    .heep_slave_resp_i(heep_slave_rsp),
-    .ext_slave_req_o(gr_heep_slave_req),
-    .ext_slave_resp_i(gr_heep_slave_resp)
-  );
-% else:
-  assign heep_core_instr_rsp = '0;
-  assign heep_core_data_rsp = '0;
-  assign heep_debug_master_rsp = '0;
-  assign heep_dma_read_rsp = '0;
-  assign heep_dma_write_rsp = '0;
-  assign heep_dma_addr_rsp = '0;
-% endif
-% if (gr_heep["xbar_nmasters"] == 0):
-  assign gr_heep_master_req = '0;
-  assign heep_slave_req = '0;
-% else:
   % if (gr_heep["xbar_nslaves"] > 0):
-  assign heep_slave_req = '0;
+    gr_heep_bus #(
+      .EXT_XBAR_NMASTER(gr_heep_pkg::ExtXbarNMaster),
+      .EXT_XBAR_NSLAVE (gr_heep_pkg::ExtXbarNSlave)
+    ) gr_heep_bus_i (
+      .clk_i(clk_in_x),
+      .rst_ni(rst_nin_sync),
+      .addr_map_i(gr_heep_pkg::ExtPeriphAddrRules),
+      .default_idx_i('0),
+      .heep_core_instr_req_i(heep_core_instr_req),
+      .heep_core_instr_resp_o(heep_core_instr_rsp),
+      .heep_core_data_req_i(heep_core_data_req),
+      .heep_core_data_resp_o(heep_core_data_rsp),
+      .heep_debug_master_req_i(heep_debug_master_req),
+      .heep_debug_master_resp_o(heep_debug_master_rsp),
+      .heep_dma_read_req_i(heep_dma_read_req),
+      .heep_dma_read_resp_o(heep_dma_read_rsp),
+      .heep_dma_write_req_i(heep_dma_write_req),
+      .heep_dma_write_resp_o(heep_dma_write_rsp),
+      .heep_dma_addr_req_i(heep_dma_addr_req),
+      .heep_dma_addr_resp_o(heep_dma_addr_rsp),
+      .ext_master_req_i(gr_heep_master_req),
+      .ext_master_resp_o(gr_heep_master_resp),
+      .heep_slave_req_o(heep_slave_req),
+      .heep_slave_resp_i(heep_slave_rsp),
+      .ext_slave_req_o(gr_heep_slave_req),
+      .ext_slave_resp_i(gr_heep_slave_resp)
+    );
+  % else:
+    assign heep_core_instr_rsp = '0;
+    assign heep_core_data_rsp = '0;
+    assign heep_debug_master_rsp = '0;
+    assign heep_dma_read_rsp = '0;
+    assign heep_dma_write_rsp = '0;
+    assign heep_dma_addr_rsp = '0;
   % endif
-% endif
+  % if (gr_heep["xbar_nmasters"] == 0):
+    assign gr_heep_master_req = '0;
+    assign heep_slave_req = '0;
+  % else:
+    % if (gr_heep["xbar_nslaves"] > 0):
+      assign heep_slave_req = '0;
+    % endif
+  % endif
   assign ext_ao_peripheral_req = '0;
 
-% if (gr_heep["periph_nslaves"] > 0):
-gr_heep_peripherals gr_heep_peripherals_i (
-  .clk_i(clk_in_x),
-  .rst_ni(rst_nin_sync),
-% if (gr_heep["xbar_nmasters"] > 0):
-  % if (gr_heep["xbar_nslaves"] > 0):
-  .gr_heep_master_req_o(gr_heep_master_req),
-  .gr_heep_master_resp_i(gr_heep_master_resp)${'' if (gr_heep["xbar_nslaves"] + gr_heep["periph_nslaves"] + gr_heep["ext_interrupts"] == 0) else ','}
+  % if (gr_heep["periph_nslaves"] > 0):
+    gr_heep_peripherals gr_heep_peripherals_i (
+      .clk_i(clk_in_x),
+      .rst_ni(rst_nin_sync),
+      % if (gr_heep["xbar_nmasters"] > 0):
+        % if (gr_heep["xbar_nslaves"] > 0):
+          .gr_heep_master_req_o(gr_heep_master_req),
+          .gr_heep_master_resp_i(gr_heep_master_resp)${'' if (gr_heep["xbar_nslaves"] + gr_heep["periph_nslaves"] + gr_heep["ext_interrupts"] == 0) else ','}
+        % else:
+          .gr_heep_master_req_o(heep_slave_req),
+          .gr_heep_master_resp_i(heep_slave_rsp)${'' if (gr_heep["xbar_nslaves"] + gr_heep["periph_nslaves"] + gr_heep["ext_interrupts"] == 0) else ','}
+        % endif
+      % endif
+      % if (gr_heep["xbar_nslaves"] > 0):
+        .gr_heep_slave_req_i(gr_heep_slave_req),
+        .gr_heep_slave_resp_o(gr_heep_slave_resp)${'' if (gr_heep["periph_nslaves"] + gr_heep["ext_interrupts"] == 0) else ','}
+      % endif
+      % if (gr_heep["periph_nslaves"] > 0):
+        .gr_heep_peripheral_req_i(heep_peripheral_req),
+        .gr_heep_peripheral_rsp_o(heep_peripheral_rsp)${'' if (gr_heep["ext_interrupts"] == 0) else ','}
+      % endif
+      % if (gr_heep["ext_interrupts"] > 0):
+        .gr_heep_peripheral_vec_int_o(ext_int_vector[${gr_heep["ext_interrupts"]-1}:0]),
+        .gr_heep_peripheral_int_o(intr_ext_peripheral)
+      %endif
+    );
   % else:
-  .gr_heep_master_req_o(heep_slave_req),
-  .gr_heep_master_resp_i(heep_slave_rsp)${'' if (gr_heep["xbar_nslaves"] + gr_heep["periph_nslaves"] + gr_heep["ext_interrupts"] == 0) else ','}
+    assign heep_peripheral_rsp = '0;
   % endif
-% endif
-% if (gr_heep["xbar_nslaves"] > 0):
-  .gr_heep_slave_req_i(gr_heep_slave_req),
-  .gr_heep_slave_resp_o(gr_heep_slave_resp)${'' if (gr_heep["periph_nslaves"] + gr_heep["ext_interrupts"] == 0) else ','}
-% endif
-% if (gr_heep["periph_nslaves"] > 0):
-  .gr_heep_peripheral_req_i(heep_peripheral_req),
-  .gr_heep_peripheral_rsp_o(heep_peripheral_rsp)${'' if (gr_heep["ext_interrupts"] == 0) else ','}
-% endif
-% if (gr_heep["ext_interrupts"] > 0):
-  .gr_heep_peripheral_vec_int_o(ext_int_vector[${gr_heep["ext_interrupts"]-1}:0]),
-  .gr_heep_peripheral_int_o(intr_ext_peripheral)
-%endif
-);
-% else:
-
-  assign heep_peripheral_rsp = '0;
-% endif
 
   assign hw_fifo_done = '0;
   assign hw_fifo_rsp = '0;
   assign ext_dma_slot_tx = '0;
   assign ext_dma_slot_rx = '0;
-% if (gr_heep["ext_interrupts"] == 0):
-  assign ext_int_vector = '0;
-  assign intr_ext_peripheral = '0;
-% else:
-  assign ext_int_vector[NEXT_INT-1:${gr_heep["ext_interrupts"]}] = '0;
-% endif
+  % if (gr_heep["ext_interrupts"] == 0):
+    assign ext_int_vector = '0;
+    assign intr_ext_peripheral = '0;
+  % else:
+    assign ext_int_vector[NEXT_INT-1:${gr_heep["ext_interrupts"]}] = '0;
+  % endif
   assign exit_value_out_x = exit_value[0];
 
   // Pad ring

--- a/hw/gr-heep/gr_heep_peripherals.sv.tpl
+++ b/hw/gr-heep/gr_heep_peripherals.sv.tpl
@@ -21,88 +21,86 @@
 module gr_heep_peripherals (
     input logic clk_i,
     input logic rst_ni${'' if gr_heep["xbar_nmasters"] == 0 and gr_heep["xbar_nslaves"] == 0 and gr_heep["periph_nslaves"] == 0 and gr_heep["ext_interrupts"] == 0 else ','}
+    
     % if (gr_heep["xbar_nmasters"] > 0):
-
-    // External peripherals master ports
-    output obi_pkg::obi_req_t  [gr_heep_pkg::ExtXbarNMasterRnd-1:0] gr_heep_master_req_o,
-    input obi_pkg::obi_resp_t [gr_heep_pkg::ExtXbarNMasterRnd-1:0] gr_heep_master_resp_i${'' if (gr_heep["xbar_nslaves"] + gr_heep["periph_nslaves"] + gr_heep["ext_interrupts"] == 0) else ','}
+        // External peripherals master ports
+        output obi_pkg::obi_req_t  [gr_heep_pkg::ExtXbarNMasterRnd-1:0] gr_heep_master_req_o,
+        input obi_pkg::obi_resp_t [gr_heep_pkg::ExtXbarNMasterRnd-1:0] gr_heep_master_resp_i${'' if (gr_heep["xbar_nslaves"] + gr_heep["periph_nslaves"] + gr_heep["ext_interrupts"] == 0) else ','}
     % endif
     % if (gr_heep["xbar_nslaves"] > 0):
-
-    // External peripherals slave ports
-    input obi_pkg::obi_req_t  [gr_heep_pkg::ExtXbarNSlaveRnd-1:0] gr_heep_slave_req_i,
-    output obi_pkg::obi_resp_t [gr_heep_pkg::ExtXbarNSlaveRnd-1:0] gr_heep_slave_resp_o${'' if (gr_heep["periph_nslaves"] + gr_heep["ext_interrupts"] == 0) else ','}
+        // External peripherals slave ports
+        input obi_pkg::obi_req_t  [gr_heep_pkg::ExtXbarNSlaveRnd-1:0] gr_heep_slave_req_i,
+        output obi_pkg::obi_resp_t [gr_heep_pkg::ExtXbarNSlaveRnd-1:0] gr_heep_slave_resp_o${'' if (gr_heep["periph_nslaves"] + gr_heep["ext_interrupts"] == 0) else ','}
     % endif
     % if (gr_heep["periph_nslaves"] > 0):
-
-    // External peripherals configuration ports
-    input reg_pkg::reg_req_t gr_heep_peripheral_req_i,
-    output reg_pkg::reg_rsp_t gr_heep_peripheral_rsp_o${'' if (gr_heep["ext_interrupts"] == 0) else ','}
+        // External peripherals configuration ports
+        input reg_pkg::reg_req_t gr_heep_peripheral_req_i,
+        output reg_pkg::reg_rsp_t gr_heep_peripheral_rsp_o${'' if (gr_heep["ext_interrupts"] == 0) else ','}
     % endif
     % if (gr_heep["ext_interrupts"] > 0):
-
-    // External peripherals interrupt ports
-    output logic [gr_heep_pkg::ExtInterrupts-1:0] gr_heep_peripheral_vec_int_o,
-    output logic     gr_heep_peripheral_int_o
+        // External peripherals interrupt ports
+        output logic [gr_heep_pkg::ExtInterrupts-1:0] gr_heep_peripheral_vec_int_o,
+        output logic     gr_heep_peripheral_int_o
     % endif
 );
 
-% if (gr_heep["ext_interrupts"] > 0):
+  % if (gr_heep["ext_interrupts"] > 0):
     logic [gr_heep_pkg::ExtInterrupts-1:0] gr_heep_peripheral_vec_int;
     assign gr_heep_peripheral_vec_int_o = gr_heep_peripheral_vec_int;
     assign gr_heep_peripheral_int_o = |gr_heep_peripheral_vec_int;
+  % endif
 
-% endif
-% if (gr_heep["periph_nslaves"] > 0):
-  reg_pkg::reg_req_t [gr_heep_pkg::ExtPeriphNSlaveRnd-1:0] gr_heep_peripheral_req;
-  reg_pkg::reg_rsp_t [gr_heep_pkg::ExtPeriphNSlaveRnd-1:0] gr_heep_peripheral_rsp;
+  % if (gr_heep["periph_nslaves"] > 0):
+    reg_pkg::reg_req_t [gr_heep_pkg::ExtPeriphNSlaveRnd-1:0] gr_heep_peripheral_req;
+    reg_pkg::reg_rsp_t [gr_heep_pkg::ExtPeriphNSlaveRnd-1:0] gr_heep_peripheral_rsp;
 
-  logic [gr_heep_pkg::LogExtPeriphNSlave-1:0] ext_periph_select;
+    logic [gr_heep_pkg::LogExtPeriphNSlave-1:0] ext_periph_select;
 
-  // External bus for register interfaces
-  addr_decode #(
-      .NoIndices(gr_heep_pkg::ExtPeriphNSlave),
-      .NoRules(gr_heep_pkg::ExtPeriphNSlave),
-      .addr_t(logic [31:0]),
-      .rule_t(addr_map_rule_pkg::addr_map_rule_t)
-  ) addr_decode_gr_heep_ext_periph_i (
-      .addr_i(gr_heep_peripheral_req_i.addr),
-      .addr_map_i(gr_heep_pkg::ExtPeriphAddrRules),
-      .idx_o(ext_periph_select),
-      .dec_valid_o(),
-      .dec_error_o(),
-      .en_default_idx_i(1'b1),
-      .default_idx_i(gr_heep_pkg::LogExtPeriphNSlave'(gr_heep_pkg::ExtPeriphDefaultIdx))
-  );
+    // External bus for register interfaces
+    addr_decode #(
+        .NoIndices(gr_heep_pkg::ExtPeriphNSlave),
+        .NoRules(gr_heep_pkg::ExtPeriphNSlave),
+        .addr_t(logic [31:0]),
+        .rule_t(addr_map_rule_pkg::addr_map_rule_t)
+    ) addr_decode_gr_heep_ext_periph_i (
+        .addr_i(gr_heep_peripheral_req_i.addr),
+        .addr_map_i(gr_heep_pkg::ExtPeriphAddrRules),
+        .idx_o(ext_periph_select),
+        .dec_valid_o(),
+        .dec_error_o(),
+        .en_default_idx_i(1'b1),
+        .default_idx_i(gr_heep_pkg::LogExtPeriphNSlave'(gr_heep_pkg::ExtPeriphDefaultIdx))
+    );
 
-  reg_demux #(
-      .NoPorts(gr_heep_pkg::ExtPeriphNSlaveRnd),
-      .req_t  (reg_pkg::reg_req_t),
-      .rsp_t  (reg_pkg::reg_rsp_t)
-  ) reg_demux_i (
-      .clk_i,
-      .rst_ni,
-      .in_select_i(ext_periph_select),
-      .in_req_i(gr_heep_peripheral_req_i),
-      .in_rsp_o(gr_heep_peripheral_rsp_o),
-      .out_req_o(gr_heep_peripheral_req),
-      .out_rsp_i(gr_heep_peripheral_rsp)
-  );
+    reg_demux #(
+        .NoPorts(gr_heep_pkg::ExtPeriphNSlaveRnd),
+        .req_t  (reg_pkg::reg_req_t),
+        .rsp_t  (reg_pkg::reg_rsp_t)
+    ) reg_demux_i (
+        .clk_i,
+        .rst_ni,
+        .in_select_i(ext_periph_select),
+        .in_req_i(gr_heep_peripheral_req_i),
+        .in_rsp_o(gr_heep_peripheral_rsp_o),
+        .out_req_o(gr_heep_peripheral_req),
+        .out_rsp_i(gr_heep_peripheral_rsp)
+    );
 
-  // Instantiate here the external peripherals
-  % for a_slave in gr_heep["peripherals"]:
-    // % if (a_slave['name'] == "TestIp"):
-    //   // Test IP
-    //   test_ip test_ip_i (
-    //       .clk_i,
-    //       .rst_ni(rst_ni),
-    //       .reg_req_i(gr_heep_peripheral_req[gr_heep_pkg::TestIpPeriphIdx]),
-    //       .reg_rsp_o(gr_heep_peripheral_rsp[gr_heep_pkg::TestIpPeriphIdx]),
-    //       .read_req_i(gr_heep_slave_req_i[gr_heep_pkg::TestIpIdx]),
-    //       .read_resp_o(gr_heep_slave_resp_o[gr_heep_pkg::TestIpIdx])
-    //   );
-    // % endif
-  % endfor
-% endif
+    // Instantiate here the external peripherals
+    % for a_slave in gr_heep["peripherals"]:
+        // % if (a_slave['name'] == "TestIp"):
+        //   // Test IP
+        //   test_ip test_ip_i (
+        //       .clk_i,
+        //       .rst_ni(rst_ni),
+        //       .reg_req_i(gr_heep_peripheral_req[gr_heep_pkg::TestIpPeriphIdx]),
+        //       .reg_rsp_o(gr_heep_peripheral_rsp[gr_heep_pkg::TestIpPeriphIdx]),
+        //       .read_req_i(gr_heep_slave_req_i[gr_heep_pkg::TestIpIdx]),
+        //       .read_resp_o(gr_heep_slave_resp_o[gr_heep_pkg::TestIpIdx]),
+        //       .gr_heep_peripheral_vec_int[0]
+        //   );
+        // % endif
+    % endfor
+  % endif
 
 endmodule

--- a/hw/gr-heep/gr_heep_pkg.sv.tpl
+++ b/hw/gr-heep/gr_heep_pkg.sv.tpl
@@ -44,32 +44,32 @@ package gr_heep_pkg;
   localparam int unsigned LogExtXbarNMaster = ExtXbarNMaster > 32'd1 ? $clog2(ExtXbarNMaster) : 32'd1;
   localparam int unsigned LogExtXbarNSlave = ExtXbarNSlave > 32'd1 ? $clog2(ExtXbarNSlave) : 32'd1;
 
-% if (gr_heep["xbar_nslaves"] > 0):
+  % if (gr_heep["xbar_nslaves"] > 0):
 
-  % for a_slave in gr_heep["slaves"]:
-    // Memory map
-    // ----------
-    // ${a_slave['name']}
-    localparam int unsigned ${a_slave['name']}Idx = 32'd${a_slave['idx']};
-    localparam logic [31:0] ${a_slave['name']}StartAddr = EXT_SLAVE_START_ADDRESS + 32'h${hex(a_slave['offset'])[2:]};
-    localparam logic [31:0] ${a_slave['name']}Size = 32'h${hex(a_slave['size'])[2:]};
-    localparam logic [31:0] ${a_slave['name']}EndAddr = ${a_slave['name']}StartAddr + 32'h${hex(a_slave['size'])[2:]};
-  % endfor
+    % for a_slave in gr_heep["slaves"]:
+      // Memory map
+      // ----------
+      // ${a_slave['name']}
+      localparam int unsigned ${a_slave['name']}Idx = 32'd${a_slave['idx']};
+      localparam logic [31:0] ${a_slave['name']}StartAddr = EXT_SLAVE_START_ADDRESS + 32'h${hex(a_slave['offset'])[2:]};
+      localparam logic [31:0] ${a_slave['name']}Size = 32'h${hex(a_slave['size'])[2:]};
+      localparam logic [31:0] ${a_slave['name']}EndAddr = ${a_slave['name']}StartAddr + 32'h${hex(a_slave['size'])[2:]};
+    % endfor
 
-  // External slaves address map
-  localparam addr_map_rule_t [ExtXbarNSlave-1:0] ExtSlaveAddrRules = '{
-    % for slave_idx, a_slave in enumerate(gr_heep["slaves"]):
-      % if (slave_idx < len(gr_heep["slaves"])-1):
-        '{idx: ${a_slave['name']}Idx, start_addr: ${a_slave['name']}StartAddr, end_addr: ${a_slave['name']}EndAddr},
-      % else:
-        '{idx: ${a_slave['name']}Idx, start_addr: ${a_slave['name']}StartAddr, end_addr: ${a_slave['name']}EndAddr}
-      %endif
-    %endfor
-  };
+    // External slaves address map
+    localparam addr_map_rule_t [ExtXbarNSlave-1:0] ExtSlaveAddrRules = '{
+      % for slave_idx, a_slave in enumerate(gr_heep["slaves"]):
+        % if (slave_idx < len(gr_heep["slaves"])-1):
+          '{idx: ${a_slave['name']}Idx, start_addr: ${a_slave['name']}StartAddr, end_addr: ${a_slave['name']}EndAddr},
+        % else:
+          '{idx: ${a_slave['name']}Idx, start_addr: ${a_slave['name']}StartAddr, end_addr: ${a_slave['name']}EndAddr}
+        %endif
+      %endfor
+    };
 
-  localparam int unsigned ExtSlaveDefaultIdx = 32'd0;
+    localparam int unsigned ExtSlaveDefaultIdx = 32'd0;
 
-% endif
+  % endif
   
   // --------------------
   // EXTERNAL PERIPHERALS
@@ -80,18 +80,18 @@ package gr_heep_pkg;
   localparam int unsigned LogExtPeriphNSlave = (ExtPeriphNSlave > 32'd1) ? $clog2(ExtPeriphNSlave) : 32'd1;
   localparam int unsigned ExtPeriphNSlaveRnd = (ExtPeriphNSlave > 32'd1) ? ExtPeriphNSlave : 32'd1;
 
-% if (gr_heep["periph_nslaves"] > 0):
+  % if (gr_heep["periph_nslaves"] > 0):
 
-  % for a_slave in gr_heep["peripherals"]:
-    // Memory map
-    // ----------
-    // ${a_slave['name']}
-    localparam int unsigned ${a_slave['name']}PeriphIdx = 32'd${a_slave['idx']};
-    localparam logic [31:0] ${a_slave['name']}PeriphStartAddr = EXT_PERIPHERAL_START_ADDRESS + 32'h${hex(a_slave['offset'])[2:]};
-    localparam logic [31:0] ${a_slave['name']}PeriphSize = 32'h${hex(a_slave['size'])[2:]};
-    localparam logic [31:0] ${a_slave['name']}PeriphEndAddr = ${a_slave['name']}PeriphStartAddr + 32'h${hex(a_slave['size'])[2:]};
-  % endfor
-    
+    % for a_slave in gr_heep["peripherals"]:
+      // Memory map
+      // ----------
+      // ${a_slave['name']}
+      localparam int unsigned ${a_slave['name']}PeriphIdx = 32'd${a_slave['idx']};
+      localparam logic [31:0] ${a_slave['name']}PeriphStartAddr = EXT_PERIPHERAL_START_ADDRESS + 32'h${hex(a_slave['offset'])[2:]};
+      localparam logic [31:0] ${a_slave['name']}PeriphSize = 32'h${hex(a_slave['size'])[2:]};
+      localparam logic [31:0] ${a_slave['name']}PeriphEndAddr = ${a_slave['name']}PeriphStartAddr + 32'h${hex(a_slave['size'])[2:]};
+    % endfor
+      
     // External peripherals address map
     localparam addr_map_rule_t [ExtPeriphNSlave-1:0] ExtPeriphAddrRules = '{
       % for slave_idx, a_slave in enumerate(gr_heep["peripherals"]):
@@ -103,9 +103,9 @@ package gr_heep_pkg;
       %endfor
     };
 
-  localparam int unsigned ExtPeriphDefaultIdx = 32'd0;
+    localparam int unsigned ExtPeriphDefaultIdx = 32'd0;
 
-% endif
+  % endif
 
   localparam int unsigned ExtInterrupts = 32'd${gr_heep["ext_interrupts"]};
 

--- a/sw/external/lib/runtime/ext_irq.c
+++ b/sw/external/lib/runtime/ext_irq.c
@@ -1,0 +1,36 @@
+// Copyright 2024 Politecnico di Torino.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-2.0. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// File: handler.c
+// Author(s):
+//   Michele Caon
+// Date: 11/11/2024
+// Description: External interrupt handlers
+
+#include "handler.h"
+#include "rv_plic.h"
+#include "csr.h"
+
+/**********************************/
+/* ---- FUNCTION DEFINITIONS ---- */
+/**********************************/
+
+int ext_irq_init(void) {
+    // Initialize PLIC for external interrupts
+    if (plic_Init() != kPlicOk)
+        return -1;
+
+    // Enable global interrupts
+    CSR_SET_BITS(CSR_REG_MSTATUS, 0x8); // mstatus.mie: globally enable machine-level interrupts
+    CSR_SET_BITS(CSR_REG_MIE, (1 << 11)); // mie.meie: enable machine-level external interrupts
+
+    // Return success
+    return 0;
+}

--- a/sw/external/lib/runtime/ext_irq.h
+++ b/sw/external/lib/runtime/ext_irq.h
@@ -1,0 +1,26 @@
+// Copyright 2024 Politecnico di Torino.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-2.0. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// File: ext_irq.h
+// Author(s):
+//   Michele Caon
+// Date: 10/11/2024
+// Description: Interrupt handling routines for GR-HEEP
+
+#ifndef EXT_IRQ_H_
+#define EXT_IRQ_H_
+
+/**
+ * @brief External interrupt initialization.
+ * 
+ */
+void ext_irq_init();
+
+#endif /* EXT_IRQ_H_ */


### PR DESCRIPTION
Add support for external interrupts.
Reformat code in the templates. Verible takes care of the formatting later, so indent ifs and loops.