### PR TITLE
Change top module name in FPGA constraints to match GR-HEEP hierarchy

### DIFF
--- a/hw/vendor/patches/x-heep/constraints.patch
+++ b/hw/vendor/patches/x-heep/constraints.patch
@@ -1,0 +1,204 @@
+diff --git a/hw/fpga/constraints/aup-zu3/constraints.xdc b/hw/fpga/constraints/aup-zu3/constraints.xdc
+index ec4af5b..a1ea11a 100644
+--- a/hw/fpga/constraints/aup-zu3/constraints.xdc
++++ b/hw/fpga/constraints/aup-zu3/constraints.xdc
+@@ -3,5 +3,5 @@ create_clock -add -name jtag_clk_pin -period 100.00 -waveform {0 5} [get_ports {
+ create_clock -add -name spi_slave_clk_pin -period 16.00 -waveform {0 5} [get_ports {spi_slave_sck_io}];
+ 
+ ### Reset Constraints
+-set_false_path -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
+-set_false_path -from x_heep_system_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
++set_false_path -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
++set_false_path -from gr_heep_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
+diff --git a/hw/fpga/constraints/common/spi_slave.xdc b/hw/fpga/constraints/common/spi_slave.xdc
+index 953cf29..883ffa2 100644
+--- a/hw/fpga/constraints/common/spi_slave.xdc
++++ b/hw/fpga/constraints/common/spi_slave.xdc
+@@ -1,79 +1,79 @@
+ ### SPI Slave Constraints
+ 
+ ### PAD Mux Constraints
+-set_case_analysis 0 x_heep_system_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_mosi/q_reg[*]/Q
+-set_case_analysis 0 x_heep_system_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_miso/q_reg[*]/Q
+-set_case_analysis 0 x_heep_system_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_sck/q_reg[*]/Q
+-set_case_analysis 0 x_heep_system_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_cs/q_reg[*]/Q
++set_case_analysis 0 gr_heep_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_mosi/q_reg[*]/Q
++set_case_analysis 0 gr_heep_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_miso/q_reg[*]/Q
++set_case_analysis 0 gr_heep_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_sck/q_reg[*]/Q
++set_case_analysis 0 gr_heep_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_cs/q_reg[*]/Q
+ 
+ ## SPI Controller (SPI Domain) to OBI plug (Core Domain)
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg2_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/curr_addr_reg[*]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg2_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/curr_addr_reg[*]/D
+ 
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg1_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/curr_addr_reg[*]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg1_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/curr_addr_reg[*]/D
+ 
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg2_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/tx_counter_reg[*]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg2_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/tx_counter_reg[*]/D
+ 
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg1_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/tx_counter_reg[*]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg1_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/tx_counter_reg[*]/D
+ 
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg2_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/FSM_sequential_OBI_CS_reg[*]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg2_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/FSM_sequential_OBI_CS_reg[*]/D
+ 
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg1_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/FSM_sequential_OBI_CS_reg[*]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg1_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/FSM_sequential_OBI_CS_reg[*]/D
+ 
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/addr_reg_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/curr_addr_reg[*]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/addr_reg_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/curr_addr_reg[*]/D
+ 
+ ## SPI RX (SPI Domain) to SPI Syncro (Core Domain)
+ set_false_path -from  spi_slave_mosi_io \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+ 
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/data_int_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/data_int_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+ 
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/counter_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/counter_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+ 
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/counter_trgt_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/counter_trgt_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+ 
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/running_reg/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/running_reg/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+ 
+ # From RXREG (SPI domain) to SPI Syncro (Core domain)
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/counter_trgt_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/counter_trgt_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+ 
+ ## SPI Controller (SPI Domain) to SPI Syncro (Core domain)
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/FSM_sequential_state_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/FSM_sequential_state_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+ 
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/cmd_reg_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/cmd_reg_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+ 
+-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/ctrl_addr_valid_reg/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/valid_reg_reg[0]/D
++set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/ctrl_addr_valid_reg/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/valid_reg_reg[0]/D
+ 
+ #CDC FIFO TX
+-set_max_delay -datapath_only -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_src/wptr_q_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_dst/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
++set_max_delay -datapath_only -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_src/wptr_q_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_dst/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
+ 
+-set_max_delay -datapath_only -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_src/gen_word[*].data_q_reg[*][*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_dst/i_spill_register/spill_register_flushable_i/gen_spill_reg.a_data_q_reg[*]/D 5.00
++set_max_delay -datapath_only -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_src/gen_word[*].data_q_reg[*][*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_dst/i_spill_register/spill_register_flushable_i/gen_spill_reg.a_data_q_reg[*]/D 5.00
+ 
+-set_max_delay -datapath_only -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_dst/rptr_q_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_src/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
++set_max_delay -datapath_only -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_dst/rptr_q_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_src/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
+ 
+ #CDC FIFO RX
+-set_max_delay -datapath_only -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_src/wptr_q_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_dst/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
++set_max_delay -datapath_only -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_src/wptr_q_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_dst/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
+ 
+-set_max_delay -datapath_only -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_src/gen_word[*].data_q_reg[*][*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_dst/i_spill_register/spill_register_flushable_i/gen_spill_reg.a_data_q_reg[*]/D 5.00
++set_max_delay -datapath_only -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_src/gen_word[*].data_q_reg[*][*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_dst/i_spill_register/spill_register_flushable_i/gen_spill_reg.a_data_q_reg[*]/D 5.00
+ 
+-set_max_delay -datapath_only -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_dst/rptr_q_reg[*]/C \
+--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_src/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
++set_max_delay -datapath_only -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_dst/rptr_q_reg[*]/C \
++-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_src/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
+diff --git a/hw/fpga/constraints/genesys2/constraints.xdc b/hw/fpga/constraints/genesys2/constraints.xdc
+index 154120d..ca51e7b 100644
+--- a/hw/fpga/constraints/genesys2/constraints.xdc
++++ b/hw/fpga/constraints/genesys2/constraints.xdc
+@@ -2,5 +2,5 @@ create_clock -add -name jtag_clk_pin -period 100.00 -waveform {0 5} [get_ports {
+ create_clock -add -name spi_slave_clk_pin -period 20.00 -waveform {0 5} [get_ports {spi_slave_sck_io}];
+ 
+ ### Reset Constraints
+-set_false_path -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
+-set_false_path -from x_heep_system_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
++set_false_path -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
++set_false_path -from gr_heep_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
+diff --git a/hw/fpga/constraints/nexys/constraints.xdc b/hw/fpga/constraints/nexys/constraints.xdc
+index a0f47a0..ec5497c 100644
+--- a/hw/fpga/constraints/nexys/constraints.xdc
++++ b/hw/fpga/constraints/nexys/constraints.xdc
+@@ -3,6 +3,6 @@ create_clock -add -name jtag_clk_pin -period 100.00 -waveform {0 5} [get_ports {
+ create_clock -add -name spi_slave_clk_pin -period 20.00 -waveform {0 5} [get_ports {spi_slave_sck_io}];
+ 
+ ### Reset Constraints
+-set_false_path -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
+-set_false_path -from x_heep_system_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
++set_false_path -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
++set_false_path -from gr_heep_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
+ 
+diff --git a/hw/fpga/constraints/pynq-z2/constraints.xdc b/hw/fpga/constraints/pynq-z2/constraints.xdc
+index ec4af5b..a1ea11a 100644
+--- a/hw/fpga/constraints/pynq-z2/constraints.xdc
++++ b/hw/fpga/constraints/pynq-z2/constraints.xdc
+@@ -3,5 +3,5 @@ create_clock -add -name jtag_clk_pin -period 100.00 -waveform {0 5} [get_ports {
+ create_clock -add -name spi_slave_clk_pin -period 16.00 -waveform {0 5} [get_ports {spi_slave_sck_io}];
+ 
+ ### Reset Constraints
+-set_false_path -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
+-set_false_path -from x_heep_system_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
++set_false_path -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
++set_false_path -from gr_heep_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
+diff --git a/hw/fpga/constraints/zcu102/constraints.xdc b/hw/fpga/constraints/zcu102/constraints.xdc
+index c8fd23f..870227c 100644
+--- a/hw/fpga/constraints/zcu102/constraints.xdc
++++ b/hw/fpga/constraints/zcu102/constraints.xdc
+@@ -2,5 +2,5 @@ create_clock -add -name jtag_clk_pin -period 100.00 -waveform {0 5} [get_ports {
+ create_clock -add -name spi_slave_clk_pin -period 16.00 -waveform {0 5} [get_ports {spi_slave_sck_io}];
+ 
+ ### Reset Constraints
+-set_false_path -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
+-set_false_path -from x_heep_system_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
++set_false_path -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
++set_false_path -from gr_heep_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
+diff --git a/hw/fpga/constraints/zcu104/constraints.xdc b/hw/fpga/constraints/zcu104/constraints.xdc
+index c8fd23f..870227c 100644
+--- a/hw/fpga/constraints/zcu104/constraints.xdc
++++ b/hw/fpga/constraints/zcu104/constraints.xdc
+@@ -2,5 +2,5 @@ create_clock -add -name jtag_clk_pin -period 100.00 -waveform {0 5} [get_ports {
+ create_clock -add -name spi_slave_clk_pin -period 16.00 -waveform {0 5} [get_ports {spi_slave_sck_io}];
+ 
+ ### Reset Constraints
+-set_false_path -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
+-set_false_path -from x_heep_system_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
++set_false_path -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
++set_false_path -from gr_heep_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C

--- a/hw/vendor/x-heep/hw/fpga/constraints/aup-zu3/constraints.xdc
+++ b/hw/vendor/x-heep/hw/fpga/constraints/aup-zu3/constraints.xdc
@@ -3,5 +3,5 @@ create_clock -add -name jtag_clk_pin -period 100.00 -waveform {0 5} [get_ports {
 create_clock -add -name spi_slave_clk_pin -period 16.00 -waveform {0 5} [get_ports {spi_slave_sck_io}];
 
 ### Reset Constraints
-set_false_path -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
-set_false_path -from x_heep_system_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
+set_false_path -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
+set_false_path -from gr_heep_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C

--- a/hw/vendor/x-heep/hw/fpga/constraints/common/spi_slave.xdc
+++ b/hw/vendor/x-heep/hw/fpga/constraints/common/spi_slave.xdc
@@ -1,79 +1,79 @@
 ### SPI Slave Constraints
 
 ### PAD Mux Constraints
-set_case_analysis 0 x_heep_system_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_mosi/q_reg[*]/Q
-set_case_analysis 0 x_heep_system_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_miso/q_reg[*]/Q
-set_case_analysis 0 x_heep_system_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_sck/q_reg[*]/Q
-set_case_analysis 0 x_heep_system_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_cs/q_reg[*]/Q
+set_case_analysis 0 gr_heep_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_mosi/q_reg[*]/Q
+set_case_analysis 0 gr_heep_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_miso/q_reg[*]/Q
+set_case_analysis 0 gr_heep_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_sck/q_reg[*]/Q
+set_case_analysis 0 gr_heep_i/pad_control_i/pad_control_reg_top_i/u_pad_mux_spi_slave_cs/q_reg[*]/Q
 
 ## SPI Controller (SPI Domain) to OBI plug (Core Domain)
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg2_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/curr_addr_reg[*]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg2_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/curr_addr_reg[*]/D
 
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg1_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/curr_addr_reg[*]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg1_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/curr_addr_reg[*]/D
 
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg2_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/tx_counter_reg[*]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg2_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/tx_counter_reg[*]/D
 
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg1_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/tx_counter_reg[*]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg1_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/tx_counter_reg[*]/D
 
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg2_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/FSM_sequential_OBI_CS_reg[*]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg2_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/FSM_sequential_OBI_CS_reg[*]/D
 
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg1_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/FSM_sequential_OBI_CS_reg[*]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/u_spiregs/reg1_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/FSM_sequential_OBI_CS_reg[*]/D
 
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/addr_reg_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/curr_addr_reg[*]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/addr_reg_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_obiplug/curr_addr_reg[*]/D
 
 ## SPI RX (SPI Domain) to SPI Syncro (Core Domain)
 set_false_path -from  spi_slave_mosi_io \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
 
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/data_int_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/data_int_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
 
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/counter_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/counter_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
 
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/counter_trgt_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/counter_trgt_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
 
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/running_reg/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/running_reg/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
 
 # From RXREG (SPI domain) to SPI Syncro (Core domain)
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/counter_trgt_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_rxreg/counter_trgt_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
 
 ## SPI Controller (SPI Domain) to SPI Syncro (Core domain)
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/FSM_sequential_state_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/FSM_sequential_state_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
 
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/cmd_reg_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/cmd_reg_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/rdwr_reg_reg[*]/D
 
-set_false_path -from  x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/ctrl_addr_valid_reg/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/valid_reg_reg[0]/D
+set_false_path -from  gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_slave_sm/ctrl_addr_valid_reg/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_syncro/valid_reg_reg[0]/D
 
 #CDC FIFO TX
-set_max_delay -datapath_only -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_src/wptr_q_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_dst/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
+set_max_delay -datapath_only -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_src/wptr_q_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_dst/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
 
-set_max_delay -datapath_only -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_src/gen_word[*].data_q_reg[*][*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_dst/i_spill_register/spill_register_flushable_i/gen_spill_reg.a_data_q_reg[*]/D 5.00
+set_max_delay -datapath_only -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_src/gen_word[*].data_q_reg[*][*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_dst/i_spill_register/spill_register_flushable_i/gen_spill_reg.a_data_q_reg[*]/D 5.00
 
-set_max_delay -datapath_only -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_dst/rptr_q_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_src/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
+set_max_delay -datapath_only -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_dst/rptr_q_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_tx/i_cdc_fifo_gray/i_src/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
 
 #CDC FIFO RX
-set_max_delay -datapath_only -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_src/wptr_q_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_dst/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
+set_max_delay -datapath_only -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_src/wptr_q_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_dst/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
 
-set_max_delay -datapath_only -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_src/gen_word[*].data_q_reg[*][*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_dst/i_spill_register/spill_register_flushable_i/gen_spill_reg.a_data_q_reg[*]/D 5.00
+set_max_delay -datapath_only -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_src/gen_word[*].data_q_reg[*][*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_dst/i_spill_register/spill_register_flushable_i/gen_spill_reg.a_data_q_reg[*]/D 5.00
 
-set_max_delay -datapath_only -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_dst/rptr_q_reg[*]/C \
--to x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_src/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00
+set_max_delay -datapath_only -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_dst/rptr_q_reg[*]/C \
+-to gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/gen_spi_slave.obi_spi_slave_i/u_dcfifo_rx/i_cdc_fifo_gray/i_src/gen_sync[*].i_sync/reg_q_reg[0]/D 5.00

--- a/hw/vendor/x-heep/hw/fpga/constraints/genesys2/constraints.xdc
+++ b/hw/vendor/x-heep/hw/fpga/constraints/genesys2/constraints.xdc
@@ -2,5 +2,5 @@ create_clock -add -name jtag_clk_pin -period 100.00 -waveform {0 5} [get_ports {
 create_clock -add -name spi_slave_clk_pin -period 20.00 -waveform {0 5} [get_ports {spi_slave_sck_io}];
 
 ### Reset Constraints
-set_false_path -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
-set_false_path -from x_heep_system_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
+set_false_path -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
+set_false_path -from gr_heep_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C

--- a/hw/vendor/x-heep/hw/fpga/constraints/nexys/constraints.xdc
+++ b/hw/vendor/x-heep/hw/fpga/constraints/nexys/constraints.xdc
@@ -3,6 +3,6 @@ create_clock -add -name jtag_clk_pin -period 100.00 -waveform {0 5} [get_ports {
 create_clock -add -name spi_slave_clk_pin -period 20.00 -waveform {0 5} [get_ports {spi_slave_sck_io}];
 
 ### Reset Constraints
-set_false_path -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
-set_false_path -from x_heep_system_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
+set_false_path -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
+set_false_path -from gr_heep_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
 

--- a/hw/vendor/x-heep/hw/fpga/constraints/pynq-z2/constraints.xdc
+++ b/hw/vendor/x-heep/hw/fpga/constraints/pynq-z2/constraints.xdc
@@ -3,5 +3,5 @@ create_clock -add -name jtag_clk_pin -period 100.00 -waveform {0 5} [get_ports {
 create_clock -add -name spi_slave_clk_pin -period 16.00 -waveform {0 5} [get_ports {spi_slave_sck_io}];
 
 ### Reset Constraints
-set_false_path -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
-set_false_path -from x_heep_system_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
+set_false_path -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
+set_false_path -from gr_heep_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C

--- a/hw/vendor/x-heep/hw/fpga/constraints/zcu102/constraints.xdc
+++ b/hw/vendor/x-heep/hw/fpga/constraints/zcu102/constraints.xdc
@@ -2,5 +2,5 @@ create_clock -add -name jtag_clk_pin -period 100.00 -waveform {0 5} [get_ports {
 create_clock -add -name spi_slave_clk_pin -period 16.00 -waveform {0 5} [get_ports {spi_slave_sck_io}];
 
 ### Reset Constraints
-set_false_path -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
-set_false_path -from x_heep_system_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
+set_false_path -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
+set_false_path -from gr_heep_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C

--- a/hw/vendor/x-heep/hw/fpga/constraints/zcu104/constraints.xdc
+++ b/hw/vendor/x-heep/hw/fpga/constraints/zcu104/constraints.xdc
@@ -2,5 +2,5 @@ create_clock -add -name jtag_clk_pin -period 100.00 -waveform {0 5} [get_ports {
 create_clock -add -name spi_slave_clk_pin -period 16.00 -waveform {0 5} [get_ports {spi_slave_sck_io}];
 
 ### Reset Constraints
-set_false_path -from x_heep_system_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
-set_false_path -from x_heep_system_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C
+set_false_path -from gr_heep_i/core_v_mini_mcu_i/debug_subsystem_i/dm_obi_top_i/i_dm_top/i_dm_csrs/dmcontrol_q_reg\[ndmreset\]/C
+set_false_path -from gr_heep_i/rstgen_i/i_rstgen_bypass/synch_regs_q_reg[3]/C


### PR DESCRIPTION
Replace `x_heep_system_i.*` paths for `gr_heep_i.*` paths in the XDC constraints for FPGA implementation.