### PR TITLE
Fix ports of peripherals in the gr-heep template

### DIFF
--- a/hw/gr-heep/gr_heep.sv.tpl
+++ b/hw/gr-heep/gr_heep.sv.tpl
@@ -325,7 +325,7 @@ module gr_heep (
   % endif
   assign ext_ao_peripheral_req = '0;
 
-  % if (gr_heep["periph_nslaves"] > 0 or xif):
+  % if (gr_heep["xbar_nmasters"] > 0 or gr_heep["xbar_nslaves"] > 0 or gr_heep["periph_nslaves"] > 0 or xif):
     gr_heep_peripherals gr_heep_peripherals_i (
       .clk_i(clk_in_x),
       .rst_ni(rst_nin_sync),

--- a/hw/gr-heep/gr_heep.sv.tpl
+++ b/hw/gr-heep/gr_heep.sv.tpl
@@ -359,7 +359,9 @@ module gr_heep (
         .xif_result_if(ext_xif)
       % endif
     );
-  % else:
+  % endif
+
+  % if not (gr_heep["periph_nslaves"] > 0):
     assign heep_peripheral_rsp = '0;
   % endif
 


### PR DESCRIPTION
This should fix the [problem](https://github.com/x-heep/GR-HEEP/issues/27#issue-4532900911) I encountered earlier today. The problem was that `heep_peripheral_rsp` is undefined when the CV-X-IF is activated, but no other extensions are present. Closes #26, Closes #27 